### PR TITLE
Version 0.8.6 "Ryoko"

### DIFF
--- a/Robit/Command/SlashCommands.cs
+++ b/Robit/Command/SlashCommands.cs
@@ -482,7 +482,7 @@ namespace Robit.Command
 
             DiscordChannel voiceChannel = ctx.Member.VoiceState.Channel;
 
-            if (message == "" && attachment == null)
+            if (string.IsNullOrEmpty(message) && attachment == null)
             {
                 await ctx.CreateResponseAsync("Message and attachment cannot both be empty", true);
                 return;
@@ -498,7 +498,7 @@ namespace Robit.Command
                 }
             }
 
-            content += $"\n{$"{ctx.Member.Mention} wanted people in '{voiceChannel.Name}' to see this:\n"}";
+            content += $"\n{$"{ctx.Member.Mention} wanted people in {voiceChannel.Mention} to see this:\n"}";
 
             if (message != "")
             {

--- a/Robit/Command/SlashCommands.cs
+++ b/Robit/Command/SlashCommands.cs
@@ -560,11 +560,15 @@ namespace Robit.Command
 
             if (AIResponse.Item1)
             {
+                response = $"**Prompt:** {prompt}\n**Reply:** {response}";
+
                 builder.WithContent(response);
             }
             else
             {
-                builder.WithContent("**System:** " + response);
+                response = $"**Prompt:** {prompt}\n**System:** {response}";
+
+                builder.WithContent(response);
             }
 
             await ctx.EditResponseAsync(builder);

--- a/Robit/Command/SlashCommands.cs
+++ b/Robit/Command/SlashCommands.cs
@@ -22,8 +22,8 @@ namespace Robit.Command
         double times = 1,
 
         [Option("Visible", "Is the ping visible to others")]
-        [DefaultValue(true)]
-        bool visible = true)
+        [DefaultValue(false)]
+        bool visible = false)
         {
             await ctx.CreateResponseAsync($"Pong {ctx.Client.Ping}ms", !visible);
             times--;
@@ -45,6 +45,10 @@ namespace Robit.Command
         [SlashCommand("Commands", "Lists all commands for the bot")]
         [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task Commands(InteractionContext ctx,
+
+        [Option("Visible", "Is the ping visible to others")]
+        [DefaultValue(false)]
+        bool visible = false)
         {
             SlashCommandsExtension slashCommandsExtension = Program.botClient.GetSlashCommands();
 
@@ -70,7 +74,7 @@ namespace Robit.Command
                 embed.AddField(name, description);
             }
 
-            await ctx.CreateResponseAsync(embed, true);
+            await ctx.CreateResponseAsync(embed, !visible);
         }
         #endregion
 
@@ -79,6 +83,10 @@ namespace Robit.Command
         [SlashCommand("Intro", "Bot introduction")]
         [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task Intro(InteractionContext ctx,
+
+        [Option("Visible", "Is the ping visible to others")]
+        [DefaultValue(true)]
+        bool visible = true)
         {
             DiscordEmbedBuilder embed = new DiscordEmbedBuilder()
             {
@@ -96,7 +104,7 @@ namespace Robit.Command
                 Title = "Hi!",
             }.AddField("GitHub", "Want to see what makes me tick or report a bug? Check my GitHub repo: \nhttps://github.com/TheRoboDoc/Robit ");
 
-            await ctx.CreateResponseAsync(embed);
+            await ctx.CreateResponseAsync(embed, !visible);
         }
 
         [SlashCommand("Github", "Posts a link to Robit's GitHub repo")]
@@ -740,10 +748,12 @@ namespace Robit.Command
             [MaximumLength(40)]
             string searchTerm,
             [Option("Result_Type", "Type of result you want to be fetch")]
+            [DefaultValue(Selection.At_Random)]
             Selection selection = Selection.At_Random,
             [Option("Count", "Max amount of matches to return", true)]
             [Minimum(1)]
             [Maximum(10)]
+            [DefaultValue(1)]
             double count = 1,
             [Option("Visible", "Sets the visibility", true)]
             [DefaultValue(false)]
@@ -872,10 +882,12 @@ namespace Robit.Command
             [MaximumLength(40)]
             string searchTerm,
             [Option("Result_Type", "Type of result you want to be fetch")]
+            [DefaultValue(Selection.At_Random)]
             Selection selection = Selection.At_Random,
             [Option("Count", "Max amount of matches to return", true)]
             [Minimum(1)]
             [Maximum(10)]
+            [DefaultValue(1)]
             double count = 1,
             [Option("Visible", "Sets the visibility", true)]
             [DefaultValue(false)]

--- a/Robit/Command/SlashCommands.cs
+++ b/Robit/Command/SlashCommands.cs
@@ -12,10 +12,12 @@ namespace Robit.Command
     {
         #region Technical
         [SlashCommand("Ping", "Pings the bot, the bot responds with the ping time in milliseconds")]
+        [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task Ping(InteractionContext ctx,
 
         [Option("Times", "Amount of times the bot should be pinged (Max 3)")]
         [DefaultValue(1)]
+        [Minimum(1)]
         [Maximum(3)]
         double times = 1,
 
@@ -41,7 +43,8 @@ namespace Robit.Command
 
         #region Help
         [SlashCommand("Commands", "Lists all commands for the bot")]
-        public static async Task Commands(InteractionContext ctx)
+        [SlashCommandPermissions(Permissions.SendMessages)]
+        public static async Task Commands(InteractionContext ctx,
         {
             SlashCommandsExtension slashCommandsExtension = Program.botClient.GetSlashCommands();
 
@@ -74,7 +77,8 @@ namespace Robit.Command
         #region Interaction
         #region Introduction
         [SlashCommand("Intro", "Bot introduction")]
-        public static async Task Intro(InteractionContext ctx)
+        [SlashCommandPermissions(Permissions.SendMessages)]
+        public static async Task Intro(InteractionContext ctx,
         {
             DiscordEmbedBuilder embed = new DiscordEmbedBuilder()
             {
@@ -105,8 +109,8 @@ namespace Robit.Command
         #region Automatic Responses
         [SlashCommandGroup(
         "Response",
-        "Add, remove, or edit bot's responses to messages. Needs permissions to manage emojis")]
-        [SlashCommandPermissions(Permissions.ManageEmojis | Permissions.AddReactions)]
+        "Add, remove, or edit bot's responses to messages.")]
+        [SlashCommandPermissions(Permissions.ManageEmojis | Permissions.AddReactions | Permissions.SendMessages)]
         public class Response
         {
             [SlashCommand("Add", "Add a response interaction")]
@@ -163,6 +167,7 @@ namespace Robit.Command
             public static async Task Remove(InteractionContext ctx,
 
             [Option("Name", "Name of the response interaction to delete")]
+            [MaximumLength(50)]
             string name,
 
             [Option("Visible", "Sets the visibility", true)]
@@ -263,6 +268,13 @@ namespace Robit.Command
                 [DefaultValue(false)]
                 bool visible = false)
             {
+                if (ctx.Member.Permissions.HasPermission(Permissions.Administrator)) //Double checking, just in case
+                {
+                    await ctx.CreateResponseAsync("You don't have admin permission to execute this command");
+
+                    return;
+                }
+
                 List<ResponseManager.ResponseEntry> responseEntries = new List<ResponseManager.ResponseEntry>();
 
                 ResponseManager.OverwriteEntries(responseEntries, ctx.Guild.Id.ToString());
@@ -310,6 +322,7 @@ namespace Robit.Command
         }
 
         [SlashCommand("Convert", "Converts a given file from one format to another")]
+        [SlashCommandPermissions(Permissions.AttachFiles | Permissions.SendMessages)]
         public static async Task Convert(InteractionContext ctx,
             [Option("Media_file", "Media file to convert from")] DiscordAttachment attachment,
             [Option("Format", "Format to convert to")] FileFormats fileFormat,
@@ -428,6 +441,7 @@ namespace Robit.Command
 
         #region Tag Voice
         [SlashCommand("Tagvoice", "Tags everyone in the same voice channel as you")]
+        [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task TagVoice(InteractionContext ctx,
             [Option("Message", "Message to ping people in current voice chat with")]
             [DefaultValue("")]
@@ -483,6 +497,7 @@ namespace Robit.Command
 
         #region AI Interactions
         [SlashCommand("Prompt", "Prompt the bot for a text response")]
+        [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task Text(InteractionContext ctx,
             [Option("AI_prompt", "The AI text prompt")]
             [MaximumLength(690)]
@@ -727,6 +742,7 @@ namespace Robit.Command
             [Option("Result_Type", "Type of result you want to be fetch")]
             Selection selection = Selection.At_Random,
             [Option("Count", "Max amount of matches to return", true)]
+            [Minimum(1)]
             [Maximum(10)]
             double count = 1,
             [Option("Visible", "Sets the visibility", true)]
@@ -858,6 +874,7 @@ namespace Robit.Command
             [Option("Result_Type", "Type of result you want to be fetch")]
             Selection selection = Selection.At_Random,
             [Option("Count", "Max amount of matches to return", true)]
+            [Minimum(1)]
             [Maximum(10)]
             double count = 1,
             [Option("Visible", "Sets the visibility", true)]

--- a/Robit/Command/SlashCommands.cs
+++ b/Robit/Command/SlashCommands.cs
@@ -273,10 +273,21 @@ namespace Robit.Command
             [SlashCommand("Wipe", "Wipe all of the response interactions")]
             [SlashCommandPermissions(Permissions.Administrator)]
             public static async Task Wipe(InteractionContext ctx,
+
+            [Option("Are_You_Sure", "Aure you sure you want to wipe all responses on the server?")]
+            bool check,
+
                 [Option("visible", "Sets the visibility", true)]
                 [DefaultValue(false)]
                 bool visible = false)
             {
+                if (!check)
+                {
+                    await ctx.CreateResponseAsync("`Are You Sure` was set to `false` canceling...");
+
+                    return;
+                }
+
                 if (ctx.Member.Permissions.HasPermission(Permissions.Administrator)) //Double checking, just in case
                 {
                     await ctx.CreateResponseAsync("You don't have admin permission to execute this command");

--- a/Robit/Command/SlashCommands.cs
+++ b/Robit/Command/SlashCommands.cs
@@ -229,6 +229,7 @@ namespace Robit.Command
 
             [SlashCommand("List", "List all the response interactions")]
             public static async Task List(InteractionContext ctx,
+
                 [Option("Visible", "Sets the commands visibility", true)]
                 [DefaultValue(false)]
                 bool visible = false)
@@ -293,8 +294,10 @@ namespace Robit.Command
             [SlashCommand("Ignore", "Should Robit's auto response ignore this channel or not")]
             [SlashCommandPermissions(Permissions.ManageChannels | Permissions.ManageMessages)]
             public static async Task Ignore(InteractionContext ctx,
+
             [Option("Ignore", "To ignore or not, true will ignore, false will not")]
             bool ignore,
+
             [Option("Visible", "Sets the visibility")]
             [DefaultValue(true)]
             bool visible = true)
@@ -451,9 +454,11 @@ namespace Robit.Command
         [SlashCommand("Tagvoice", "Tags everyone in the same voice channel as you")]
         [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task TagVoice(InteractionContext ctx,
+
             [Option("Message", "Message to ping people in current voice chat with")]
             [DefaultValue("")]
             string message = "",
+
             [Option("Attachment", "File attachment to the ping message")]
             [DefaultValue(null)]
             DiscordAttachment? attachment = null)
@@ -507,6 +512,7 @@ namespace Robit.Command
         [SlashCommand("Prompt", "Prompt the bot for a text response")]
         [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task Text(InteractionContext ctx,
+
             [Option("AI_prompt", "The AI text prompt")]
             [MaximumLength(690)]
             string prompt,
@@ -556,8 +562,10 @@ namespace Robit.Command
         [SlashCommand("AI_Ignore", "Should Robit's AI module ignore this channel, prompt command will still work")]
         [SlashCommandPermissions(Permissions.ManageChannels | Permissions.ManageMessages)]
         public static async Task AIIgnore(InteractionContext ctx,
+
             [Option("Ignore", "To ignore or not, true will ignore, false will not")]
             bool ignore,
+
             [Option("Visible", "Sets the visibility")]
             [DefaultValue(true)]
             bool visible = true)
@@ -581,17 +589,31 @@ namespace Robit.Command
         [SlashCommandPermissions(Permissions.SendMessages)]
         public class RandomCommands
         {
+            public enum DiceTypes
+            {
+                D2 = 2,
+                D4 = 4,
+                D6 = 6,
+                D8 = 8,
+                D10 = 10,
+                D12 = 12,
+                D20 = 20,
+            }
+
             [SlashCommand("Number", "Generates a psudorandom number within given range")]
             public static async Task Number(InteractionContext ctx,
+
             [Option("Maximum_value", "Maximum value for the random number")]
             [Minimum(0)]
             [Maximum(int.MaxValue)]
             double maximal,
+
             [Option("Minimal_value", "Minimal value for the random number")]
             [DefaultValue(0)]
             [Minimum(0)]
             [Maximum(int.MaxValue)]
             double minimal = 0,
+
             [Option("Visible", "Sets the visibility")]
             [DefaultValue(true)]
             bool visible = true)
@@ -615,26 +637,18 @@ namespace Robit.Command
                 await ctx.CreateResponseAsync($"Random number: {randomValue}", !visible);
             }
 
-            public enum DiceTypes
-            {
-                D2 = 2,
-                D4 = 4,
-                D6 = 6,
-                D8 = 8,
-                D10 = 10,
-                D12 = 12,
-                D20 = 20,
-            }
-
             [SlashCommand("Dice", "Roll dice")]
             public static async Task Dice(InteractionContext ctx,
+
             [Option("Dice_type", "Type of dice to roll")]
             DiceTypes dice,
+
             [Option("Amount", "Amount of dice to roll")]
             [Minimum(1)]
             [Maximum(255)]
             [DefaultValue(1)]
             double amount = 1,
+
             [Option("Visible", "Sets the visibility", true)]
             [DefaultValue(true)]
             bool visible = true)
@@ -744,17 +758,21 @@ namespace Robit.Command
 
             [SlashCommand("By_Author", "Search quotes by in universe author")]
             public static async Task ByAuthor(InteractionContext ctx,
+
             [Option("Search", "Search term to search by")]
             [MaximumLength(40)]
             string searchTerm,
+
             [Option("Result_Type", "Type of result you want to be fetch")]
             [DefaultValue(Selection.At_Random)]
             Selection selection = Selection.At_Random,
+
             [Option("Count", "Max amount of matches to return", true)]
             [Minimum(1)]
             [Maximum(10)]
             [DefaultValue(1)]
             double count = 1,
+
             [Option("Visible", "Sets the visibility", true)]
             [DefaultValue(false)]
             bool visible = false)
@@ -878,17 +896,21 @@ namespace Robit.Command
 
             [SlashCommand("By_Source", "Search quotes by source")]
             public static async Task BySource(InteractionContext ctx,
+
             [Option("Search", "Search term to search by")]
             [MaximumLength(40)]
             string searchTerm,
+
             [Option("Result_Type", "Type of result you want to be fetch")]
             [DefaultValue(Selection.At_Random)]
             Selection selection = Selection.At_Random,
+
             [Option("Count", "Max amount of matches to return", true)]
             [Minimum(1)]
             [Maximum(10)]
             [DefaultValue(1)]
             double count = 1,
+
             [Option("Visible", "Sets the visibility", true)]
             [DefaultValue(false)]
             bool visible = false)
@@ -1012,6 +1034,7 @@ namespace Robit.Command
 
             [SlashCommand("Random", "Fetches a random Warhammer 40k quote")]
             public static async Task RandomQuote(InteractionContext ctx,
+
             [Option("Visible", "Sets the visibility", true)]
             [DefaultValue(true)]
             bool visible = true)

--- a/Robit/Command/SlashCommands.cs
+++ b/Robit/Command/SlashCommands.cs
@@ -230,9 +230,9 @@ namespace Robit.Command
             [SlashCommand("List", "List all the response interactions")]
             public static async Task List(InteractionContext ctx,
 
-                [Option("Visible", "Sets the commands visibility", true)]
-                [DefaultValue(false)]
-                bool visible = false)
+            [Option("Visible", "Sets the commands visibility", true)]
+            [DefaultValue(false)]
+            bool visible = false)
             {
                 List<ResponseManager.ResponseEntry>? responseEntries = new List<ResponseManager.ResponseEntry>();
 
@@ -277,9 +277,9 @@ namespace Robit.Command
             [Option("Are_You_Sure", "Aure you sure you want to wipe all responses on the server?")]
             bool check,
 
-                [Option("visible", "Sets the visibility", true)]
-                [DefaultValue(false)]
-                bool visible = false)
+            [Option("visible", "Sets the visibility", true)]
+            [DefaultValue(false)]
+            bool visible = false)
             {
                 if (!check)
                 {
@@ -346,9 +346,9 @@ namespace Robit.Command
         [SlashCommand("Convert", "Converts a given file from one format to another")]
         [SlashCommandPermissions(Permissions.AttachFiles | Permissions.SendMessages)]
         public static async Task Convert(InteractionContext ctx,
-            [Option("Media_file", "Media file to convert from")] DiscordAttachment attachment,
-            [Option("Format", "Format to convert to")] FileFormats fileFormat,
-            [Option("Visible", "Sets the visibility", true)][DefaultValue(false)] bool visible = false)
+        [Option("Media_file", "Media file to convert from")] DiscordAttachment attachment,
+        [Option("Format", "Format to convert to")] FileFormats fileFormat,
+        [Option("Visible", "Sets the visibility", true)][DefaultValue(false)] bool visible = false)
         {
             await MediaManager.ClearChannelTempFolder(ctx.Interaction.Id.ToString());
 
@@ -466,13 +466,13 @@ namespace Robit.Command
         [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task TagVoice(InteractionContext ctx,
 
-            [Option("Message", "Message to ping people in current voice chat with")]
-            [DefaultValue("")]
-            string message = "",
+        [Option("Message", "Message to ping people in current voice chat with")]
+        [DefaultValue("")]
+        string message = "",
 
-            [Option("Attachment", "File attachment to the ping message")]
-            [DefaultValue(null)]
-            DiscordAttachment? attachment = null)
+        [Option("Attachment", "File attachment to the ping message")]
+        [DefaultValue(null)]
+        DiscordAttachment? attachment = null)
         {
             if (ctx.Member.VoiceState.Channel == null)
             {
@@ -524,13 +524,13 @@ namespace Robit.Command
         [SlashCommandPermissions(Permissions.SendMessages)]
         public static async Task Text(InteractionContext ctx,
 
-            [Option("AI_prompt", "The AI text prompt")]
-            [MaximumLength(690)]
-            string prompt,
+        [Option("AI_prompt", "The AI text prompt")]
+        [MaximumLength(690)]
+        string prompt,
 
-            [Option("Visible", "Sets the visibility", true)]
-            [DefaultValue(true)]
-            bool visible = true)
+        [Option("Visible", "Sets the visibility", true)]
+        [DefaultValue(true)]
+        bool visible = true)
         {
             await ctx.CreateResponseAsync("https://cdn.discordapp.com/attachments/1051011721755623495/1085873228049809448/RobitThink.gif", !visible);
 
@@ -578,12 +578,12 @@ namespace Robit.Command
         [SlashCommandPermissions(Permissions.ManageChannels | Permissions.ManageMessages)]
         public static async Task AIIgnore(InteractionContext ctx,
 
-            [Option("Ignore", "To ignore or not, true will ignore, false will not")]
-            bool ignore,
+        [Option("Ignore", "To ignore or not, true will ignore, false will not")]
+        bool ignore,
 
-            [Option("Visible", "Sets the visibility")]
-            [DefaultValue(true)]
-            bool visible = true)
+        [Option("Visible", "Sets the visibility")]
+        [DefaultValue(true)]
+        bool visible = true)
         {
             string guildID = ctx.Guild.Id.ToString();
             string channelID = ctx.Channel.Id.ToString();
@@ -846,6 +846,8 @@ namespace Robit.Command
                             Description = quoteText
                         };
 
+                        embedBuilder.WithFooter($"Quote search for in universe author result {i + 1}/{count} for search term '{searchTerm}'");
+
                         if (!string.IsNullOrEmpty(entry.bookSource))
                         {
                             embedBuilder.AddField("Source:", entry.bookSource);
@@ -890,6 +892,8 @@ namespace Robit.Command
                     {
                         embedBuilder.AddField("Source:", entry.bookSource);
                     }
+
+                    embedBuilder.WithFooter($"Quote search for in universe author result for search term '{searchTerm}'");
 
                     if (foundEntries.IndexOf(entry) == 0)
                     {
@@ -984,6 +988,8 @@ namespace Robit.Command
                             Description = quoteText
                         };
 
+                        embedBuilder.WithFooter($"Quote search for real life source result {i + 1}/{count} for search term '{searchTerm}'");
+
                         if (!string.IsNullOrEmpty(entry.bookSource))
                         {
                             embedBuilder.AddField("Source:", entry.bookSource);
@@ -1023,6 +1029,8 @@ namespace Robit.Command
                         Color = DiscordColor.Purple,
                         Description = quoteText
                     };
+
+                    embedBuilder.WithFooter($"Quote search for real life source result for search term '{searchTerm}'");
 
                     if (!string.IsNullOrEmpty(entry.bookSource))
                     {


### PR DESCRIPTION
### Commands
- Ping now requires 'send message' permission
- Ping count now has a min value of 1
- Commands now require 'send message' permission
- Intro now requires 'send message' permission
- Response group now requires 'send message' permission
- Response Remove name input max length is now 50 characters
- Response Wipe now double checks for admin permissions
- Convert now requires 'attach file' and 'send message' permissions
- TagVoice now requires 'send message' permissions
- Prompt now requires 'send message' permissions
- Wh40kquote By_Author count now has min value of 1
- Wh40kquote By_Source count now has min value of 1
- Ping default visibility is now false
- Commands default visibility is now false
- Intro default visibility is now true
- Wh40kquote By_Author default result type is now at random
- Wh40kquote By_Author default count is now 1
- Wh40kquote By_Source default result type is now at random
- Wh40kquote By_Source default count is now 1
- Response Wipe now forces you to answer that are you sure that you want to trigger it
- Adjustment of TagVoice
- Wh40kquote By_Author and By_Source now print out a footer at the end of the embed of the result count, type, and what search term was used
- Prompts command now prints following
**Prompt:** [prompt]
**Reply:** [reply]
or
**Prompt:** [prompt]
**System:** [reason]